### PR TITLE
Delta-128 Quasar Boilerplate > Plugins > Add support for translating properties of an object

### DIFF
--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -19,6 +19,7 @@ import i18n from 'src/helpers/i18n';
  * this.$trans(obj, ['key1', 'key2']); // returns obj with translated specified properties
  * this.$trans(obj, ['key1', 'key2'], true); // returns obj with the translated specified properties only
  * this.$trans(obj, ['nested.key']); // also supports nested properties
+ * this.$trans(obj, 'single-key'); // also supports single key using string
  */
 const i18nPlugin = {
     install(Vue) {
@@ -50,23 +51,25 @@ const i18nPlugin = {
 
                     /**
                      * translate some properties of an object:
+                     * this.$t(obj, 'key1');
                      * this.$t(obj, ['key1', 'key2'])
                      * trim other properties
                      * this.$t(obj, ['key1', 'key2'], true)
                      */
-                    if (_.isPlainObject(obj) && _.isArray(props)) {
+                    if (_.isPlainObject(obj) && (_.isString(props) || _.isArray(props))) {
 
-                        const objClone = _.cloneDeep(obj);
-                        const accumulator = trim ? _.pick(objClone, props) : objClone;
+                        props = _.isArray(props) ? props : [props];
+                        // Create a new object to avoid unnecessary behaviors when parameter is mutated.
+                        const accumulator = _.pick(obj, trim ? props : _.keys(obj));
 
                         return _.transform(props, (result, prop) => {
                             if (_.has(result, prop)) {
-                                _.set(result, prop, this.$trans(_.get(result, prop), props, trim));
+                                _.set(result, prop, this.$trans(_.get(result, prop)));
                             }
                         }, accumulator);
                     }
 
-                    return null;
+                    return obj;
                 }
             }
         })

--- a/test/unit/specs/plugins/i18n.spec.js
+++ b/test/unit/specs/plugins/i18n.spec.js
@@ -51,8 +51,28 @@ describe('i18nPlugin', function () {
         wrapper.vm.$trans('key1').should.be.equals('value1');
     });
 
+    it('$trans mixin method should return null when given null', function () {
+        should.equal(wrapper.vm.$trans(null), null);
+    });
+
+    it('$trans mixin method should return undefined when no keys passed', function () {
+        should.equal(wrapper.vm.$trans(undefined), undefined);
+    });
+
+    it('$trans mixin method should return untranslated key', function () {
+        wrapper.vm.$trans('unknown-key').should.be.equals('unknown-key');
+    });
+
     it('$trans mixin method should translate array of keys', function () {
         wrapper.vm.$trans(['key1', 'key2']).should.deep.equals(['value1', 'value2']);
+    });
+
+    it('$trans mixin method should translate array of keys and return untranslated keys', function () {
+        wrapper.vm.$trans(['key1', 'unknown-key']).should.deep.equals(['value1', 'unknown-key']);
+    });
+
+    it('$trans mixin method should return empty array when given an empty array', function () {
+        wrapper.vm.$trans([]).should.deep.equals([]);
     });
 
     it('$trans mixin method should translate specified keys of an object', function () {
@@ -96,5 +116,30 @@ describe('i18nPlugin', function () {
     it('$trans mixin method should not translate a nested property of an object mapped to an object', function () {
         wrapper.vm.$trans({ keys: { subkeys: {} }, extraKey: 'extra' }, ['keys.subkeys'], true)
             .should.deep.equals({ keys: { subkeys: {} } });
+    });
+
+    it('$trans mixin method should return the object when props is not given', function () {
+        wrapper.vm.$trans({ key1: 'key1', key2: 'key2', extraKey: 'extra' })
+            .should.deep.equals({ key1: 'key1', key2: 'key2', extraKey: 'extra' });
+    });
+
+    it('$trans mixin method should return the object when props is null', function () {
+        wrapper.vm.$trans({ key1: 'key1', key2: 'key2', extraKey: 'extra' }, null)
+            .should.deep.equals({ key1: 'key1', key2: 'key2', extraKey: 'extra' });
+    });
+
+    it('$trans mixin method should support single property for object using string', function () {
+        wrapper.vm.$trans({ key1: 'key1', key2: 'key2', extraKey: 'extra' }, 'key1')
+            .should.deep.equals({ key1: 'value1', key2: 'key2', extraKey: 'extra' });
+    });
+
+    it('$trans mixin method should not inject a missing property to the object', function () {
+        wrapper.vm.$trans({ key1: 'key1', key2: 'key2', extraKey: 'extra' }, 'missing-key')
+            .should.deep.equals({ key1: 'key1', key2: 'key2', extraKey: 'extra' });
+    });
+
+    it('$trans mixin method should return property value when no matching translation', function () {
+        wrapper.vm.$trans({ key1: 'key1', key2: 'key2', extraKey: 'extra' }, 'extraKey')
+            .should.deep.equals({ key1: 'key1', key2: 'key2', extraKey: 'extra' });
     });
 });


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [Delta-128](https://freedom.myjetbrains.com/youtrack/issue/Delta-128)

## Summary of changes
<!--
    Describe the change and why it was introduced. Ideally, this will also be
    used as the commit message when we do squash merge.

    This is better presented in paragraph form. Only use bullet form when
    enumerating specific parts of the change.

    Include screenshots, if possible.
-->
Based on this discussion: https://github.com/anyTV/freedom-partner-dashboard/pull/1#discussion_r164004740,
the boilerplate should support the translation of properties inside an object. In addition, since it already supports object, it would be nice to also support an array of keys to be translated.
However, we cannot use Vue filters for translating array or object of keys and return an array or object since filters should return a string to be able to be used for piping (e.g. 'key' | $t | uppercase ). Thus, a mixin is required to inject a method called `$trans` to accommodate our needs.

## Checklist
<!--
     Mark the things that have been followed.
-->
- [ ] bugfix
- [x] new feature
- [ ] breaking change
- [x] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated