### PR TITLE
Dev-2582 Quasar Boilerplate > Test > Fixed unit test for FormField

### DIFF
--- a/test/unit/specs/components/partials/form/FormField.spec.js
+++ b/test/unit/specs/components/partials/form/FormField.spec.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import {
     mount,
+    shallow,
     createLocalVue
 } from '@vue/test-utils';
 import Vuelidate from 'vuelidate';
@@ -53,6 +54,8 @@ describe('FormField.vue', function () {
             'uploader': QUploader,
         };
 
+        const stubComponent = '<div class="quasar"></div>';
+
         _.forOwn(quasarComponents, (value, key) => {
             const wrapper = mount(FormField, {
                 propsData: {
@@ -62,10 +65,13 @@ describe('FormField.vue', function () {
                     fieldProps: {}
                 },
                 localVue,
+                stubs: {
+                    [`q-${key}`]: stubComponent,
+                }
             });
 
             wrapper.contains(QField).should.be.equals(true);
-            wrapper.contains(value).should.be.equals(true);
+            wrapper.contains('.quasar').should.be.equals(true);
         });
     });
 
@@ -120,7 +126,7 @@ describe('FormField.vue', function () {
         };
 
         _.forOwn(quasarComponents, (value, key) => {
-            const wrapper = mount(FormField, {
+            const wrapper = shallow(FormField, {
                 propsData: {
                     type: key,
                     model: '',


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [Dev-2582](https://freedom.myjetbrains.com/youtrack/issue/Dev-2582)

## Summary of changes
<!--
    Describe the change and why it was introduced. Ideally, this will also be
    used as the commit message when we do squash merge.

    This is better presented in paragraph form. Only use bullet form when
    enumerating specific parts of the change.

    Include screenshots, if possible.
-->
Fixed failing unit tests in Jenkins due to error logs produced by mounting quasar component with a required object model. The assertions passed however, it will produce a stack trace for validated props when using `mount`, instead use `shallow` or stub the necessary components.

## Checklist
<!--
     Mark the things that have been followed.
-->
- [x] bugfix
- [ ] new feature
- [ ] breaking change
- [x] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated


