### PR TITLE
Dev-3801 Dependency Issue > Lock all codebase vue and vue compiler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,29 +17,29 @@
     },
     "dependencies": {
         "@panter/vue-i18next": "^0.15.1",
-        "@quasar/app": "^1.9.6",
-        "@quasar/extras": "^1.9.9",
+        "@quasar/app": "1.9.6",
+        "@quasar/extras": "1.9.9",
         "axios": "^0.19.0",
         "i18next": "^10.2.2",
         "i18next-browser-languagedetector": "^2.1.0",
-        "i18next-xhr-backend": "^1.5.1",
+        "i18next-http-backend": "^1.2.4",
         "jsonwebtoken": "^8.2.1",
         "lodash-es": "^4.17.10",
         "moment": "^2.20.1",
         "qs": "^6.5.2",
-        "quasar": "^1.14.1",
-        "vue": "^2.5.16",
+        "quasar": "1.14.1",
+        "vue": "2.5.16",
         "vue-gtm": "3.1.0-vue2",
-        "vue-router": "^3.0.1",
-        "vue-template-compiler": "^2.6.7",
+        "vue-router": "3.0.1",
+        "vue-template-compiler": "2.6.7",
         "vuelidate": "^0.6.2",
-        "vuex": "^3.0.1"
+        "vuex": "3.0.1"
     },
     "dependenciesComments": {
         "vue-gtm": "Default packages are built for vue3, use `-vue2` for all packages that would be installed. @see https://github.com/mib200/vue-gtm/issues/98"
     },
     "devDependencies": {
-        "@quasar/cli": "^1.1.2",
+        "@quasar/cli": "1.1.2",
         "babel-eslint": "^8.2.1",
         "esdoc": "^1.1.0",
         "esdoc-standard-plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "moment": "^2.20.1",
         "qs": "^6.5.2",
         "quasar": "1.14.1",
-        "vue": "2.5.16",
+        "vue": "2.6.11",
         "vue-gtm": "3.1.0-vue2",
         "vue-router": "3.0.1",
-        "vue-template-compiler": "2.6.7",
+        "vue-template-compiler": "2.6.11",
         "vuelidate": "^0.6.2",
         "vuex": "3.0.1"
     },
@@ -41,6 +41,7 @@
     "devDependencies": {
         "@quasar/cli": "1.1.2",
         "babel-eslint": "^8.2.1",
+        "cross-env": "^7.0.3",
         "esdoc": "^1.1.0",
         "esdoc-standard-plugin": "^1.0.0",
         "eslint": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     },
     "dependencies": {
         "@panter/vue-i18next": "^0.15.1",
-        "@quasar/app": "1.9.6",
-        "@quasar/extras": "1.9.9",
+        "@quasar/app": "^1.9.6",
+        "@quasar/extras": "^1.9.9",
         "axios": "^0.19.0",
         "i18next": "^10.2.2",
         "i18next-browser-languagedetector": "^2.1.0",
@@ -27,19 +27,19 @@
         "lodash-es": "^4.17.10",
         "moment": "^2.20.1",
         "qs": "^6.5.2",
-        "quasar": "1.14.1",
+        "quasar": "^1.14.1",
         "vue": "2.6.11",
         "vue-gtm": "3.1.0-vue2",
-        "vue-router": "3.0.1",
+        "vue-router": "^3.0.1",
         "vue-template-compiler": "2.6.11",
         "vuelidate": "^0.6.2",
-        "vuex": "3.0.1"
+        "vuex": "^3.0.1"
     },
     "dependenciesComments": {
         "vue-gtm": "Default packages are built for vue3, use `-vue2` for all packages that would be installed. @see https://github.com/mib200/vue-gtm/issues/98"
     },
     "devDependencies": {
-        "@quasar/cli": "1.1.2",
+        "@quasar/cli": "^1.1.2",
         "babel-eslint": "^8.2.1",
         "cross-env": "^7.0.3",
         "esdoc": "^1.1.0",

--- a/src/boot/vue-i18next.js
+++ b/src/boot/vue-i18next.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import i18nextXHRBackend from 'i18next-xhr-backend';
+import i18nextHttpBackend from 'i18next-http-backend';
 import i18nextLangDetector from 'i18next-browser-languagedetector';
 import VueI18next from '@panter/vue-i18next';
 import i18nextConfig from 'src/config/i18next';
@@ -33,7 +33,7 @@ export default ({ app, Vue }) => {
     i18next.use(i18nextLangDetector);
 
     if (i18nextConfig.backend) {
-        i18next.use(i18nextXHRBackend);
+        i18next.use(i18nextHttpBackend);
     }
 
     i18next.init(i18nextConfig);


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [Dev-3801](https://freedom.myjetbrains.com/youtrack/issue/Dev-3801)

## Summary of changes
- Fix: matched  versions of vue and vue-template-compiler
- Feat: Updated depracated i18next-xhr-backend to i18next-http-backend
<!--
    Describe the change and why it was introduced. Ideally, this will also be
    used as the commit message when we do squash merge.

    This is better presented in paragraph form. Only use bullet form when
    enumerating specific parts of the change.

    Include screenshots, if possible.
-->

## Checklist
<!--
     Mark the things that have been followed.
-->
- [ ] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
<!--
    Include this if we need manual testing and not a unit test.
    If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->
1. Run the following
```
rm -rf node_modules/
rm package-lock.json
npm i
npm run dev
```

2. Go to https://localhost:8080/table-with-tabs