### PR TITLE
Bump Version v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "anytv-quasar-boilerplate",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "AnyTV Quasar Boilerplate",
     "repository": "https://github.com/anyTV/quasar-boilerplate",
     "productName": "Freedom! App",


### PR DESCRIPTION
### Dev-3801 Dependency Issue > Lock all codebase vue and vue compiler version #35
- Fix: matched versions of vue and vue-template-compiler
- Feat: Updated depracated i18next-xhr-backend to i18next-http-backend
