### PR TITLE
Bump version to v1.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+Version 1.6.0:
+ - Dev-4278 OKR > Content ID > Upgrade from eslint-loader to eslint-webpack-plugin [(#52)](https://github.com/anyTV/quasar-boilerplate/pull/52)
+
 Version 1.5.3:
  - Delta-1642 Platform > Freedom Components > FHistory [(#50)](https://github.com/anyTV/quasar-boilerplate/pull/50)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "anytv-quasar-boilerplate",
-    "version": "1.5.3",
+    "version": "1.6.0",
     "description": "AnyTV Quasar Boilerplate",
     "repository": "https://github.com/anyTV/quasar-boilerplate",
     "productName": "Freedom! App",


### PR DESCRIPTION
###  Dev-4278 OKR > Content ID > Upgrade from eslint-loader to eslint-webpack-plugin #52 
Feature:
* Replaced eslint-loader by eslint-webpack-plugin and fixed lint errors. Ran lint-fix script and other manual changes to fix lint warnings.